### PR TITLE
cmake: set ctest arguments from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.21)
 
 project(cmake-catch2-ci-example CXX C ASM)
 
+# Must be set before including CTest so that these arguments are applied when
+# running `$ ninja test` or `$ make test`.
+set(CMAKE_CTEST_ARGUMENTS "--output-on-failure" "--output-junit" "junit.xml")
 # This must be in the top-level CMakeLists.txt to enable CMake/CTest support.
 include(CTest)
 


### PR DESCRIPTION
This way, `make test` or `ninja test` uses the right arguments.